### PR TITLE
🛡️ Sentinel: [HIGH] Disable debug mode in Dockerfile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-12 - [Disable Debug Mode in Production Dockerfile]
+**Vulnerability:** The Dockerfile exposed the Fava/Flask debug mode (`ENV FAVA_DEBUG "true"`) in production, which could leak stack traces and potentially internal environment configuration details to end users.
+**Learning:** Containerized applications, especially those built to be shared or run in production like fava-docker, should never default to development debug modes due to the inherent risk of information disclosure via verbose error pages.
+**Prevention:** Always default web framework debug settings to false or off in the final stages of Dockerfile builds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ ENV BEANCOUNT_FILE ""
 ENV FAVA_HOST "0.0.0.0"
 ENV PATH "/app/bin:$PATH"
 ENV PYTHONPATH "/myData/myTools:$PYTHONPATH"
-ENV FAVA_DEBUG "true"
+# Security Fix: Disable debug mode in production to prevent leaking sensitive information
+ENV FAVA_DEBUG "false"
 ENTRYPOINT ["fava"]


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Dockerfile configured Fava to run with `FAVA_DEBUG="true"`, meaning that the underlying Flask/Werkzeug application would launch in debug mode. In production, this can expose detailed stack traces, internal variables, and sometimes an interactive debugger to users upon exceptions, leading to information disclosure.
🎯 **Impact:** An attacker could trigger an error and extract internal system structure, configuration details, or potentially exploit the debugger to gain unauthorized access.
🔧 **Fix:** Set `ENV FAVA_DEBUG "false"` to ensure the application fails securely without leaking sensitive internal details.
✅ **Verification:** Verified that the Dockerfile builds successfully and correctly sets the environment variable to false.

---
*PR created automatically by Jules for task [5954387000978995850](https://jules.google.com/task/5954387000978995850) started by @grostim*