### PR TITLE
🛡️ Sentinel: [security improvement] Secure Dockerfile and pin git dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+testenv/

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The Dockerfile exposed the Fava/Flask debug mode (`ENV FAVA_DEBUG "true"`) in production, which could leak stack traces and potentially internal environment configuration details to end users.
 **Learning:** Containerized applications, especially those built to be shared or run in production like fava-docker, should never default to development debug modes due to the inherent risk of information disclosure via verbose error pages.
 **Prevention:** Always default web framework debug settings to false or off in the final stages of Dockerfile builds.
+
+## 2024-06-18 - [Supply Chain Security: Pinning Git Dependencies and Avoiding ADD]
+**Vulnerability:** The project relied on mutable git branch references (`@main`, `@master`) and direct branch zip downloads for several dependencies, exposing the build to potential upstream branch poisoning or unexpected breakages. Additionally, the Dockerfile used the `ADD` instruction to copy `requirements.txt`, which can unexpectedly fetch remote URLs or extract archives, introducing a risk of manipulation.
+**Learning:** In a containerized build environment, all external dependencies and source files must be explicitly pinned (using exact commit SHAs or version numbers) to guarantee reproducible and secure builds. Using `ADD` when only copying local files violates the principle of least privilege.
+**Prevention:** Always use `COPY` for local files in Dockerfiles and avoid mutable references (like branch names) in requirements files; always use exact commit hashes or immutable release tags for git-based dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 
 ENV PATH "/app/bin:$PATH"
 RUN python3 -mvenv /app
-ADD requirements.txt .
+COPY requirements.txt .
 RUN pip3 install --no-cache-dir -U -r requirements.txt
 
 RUN pip3 uninstall -y pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ beancount-periodic>=0.2.1
 beancount-reds-plugins>=0.4.0
 beancount-periodic>=0.1.2
 smart-importer>=1.2
-fava-investor @ git+https://github.com/redstreet/fava_investor.git@main
-#bean-price @ git+https://github.com/beancount/beanprice.git@master
-https://codeload.github.com/beancount/beanprice/zip/refs/heads/master
+fava-investor @ git+https://github.com/redstreet/fava_investor.git@f83db450ae3bd47d228c0fcc8b0db7b954f51d26
+#bean-price @ git+https://github.com/beancount/beanprice.git@ab9e0cc2f03029d5af59f5bfcea38f03e271fb3d
+https://codeload.github.com/beancount/beanprice/zip/ab9e0cc2f03029d5af59f5bfcea38f03e271fb3d
 iexfinance>=0.5.0
 pricehist>=1.4.16
 tariochbctools>=1.6.3
 pricehist>=1.4.14
 tariochbctools>=0.32.0
-fava-dashboards @ git+https://github.com/andreasgerstmayr/fava-dashboards.git@main
+fava-dashboards @ git+https://github.com/andreasgerstmayr/fava-dashboards.git@ca0f13620edf38280c05c8148d475eae25de8cf4
 fava-plugins >=1.2


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Secure Dockerfile and pin git dependencies

**Vulnerability:** The project relied on mutable git branch references (`@main`, `@master`) and direct branch zip downloads for several dependencies in `requirements.txt`. Additionally, the Dockerfile used the `ADD` instruction to copy `requirements.txt`.
**Impact:** Using mutable branch references exposes the build to potential upstream branch poisoning or unexpected breakages. Using `ADD` when only copying local files violates the principle of least privilege, as it can unexpectedly fetch remote URLs or extract archives.
**Fix:**
- Replaced `ADD requirements.txt .` with `COPY requirements.txt .` in `Dockerfile`.
- Pinned all mutable git dependencies to exact, immutable commit SHAs in `requirements.txt`.
- Logged the findings in `.jules/sentinel.md`.
**Verification:**
- Verified that `pip install -r requirements.txt` successfully installs the pinned versions.
- Code review passed.

---
*PR created automatically by Jules for task [13384561253020200738](https://jules.google.com/task/13384561253020200738) started by @grostim*