### PR TITLE
⚡ Bolt: [performance improvement] Optimize Dockerfile layer caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2026-07-30 - [Enable GitHub Actions caching for Docker builds]
 **Learning:** Found that the Docker build workflow (.github/workflows/push-to-docker-hub.yaml) was not utilizing GitHub Actions cache, leading to slower cross-platform image builds because layers were recomputed on every run.
 **Action:** Next time, always enable Docker layer caching in GitHub Actions by adding `cache-from: type=gha` and `cache-to: type=gha,mode=max` to the `docker/build-push-action` step to drastically improve build performance.
+## 2024-08-01 - [Optimize Dockerfile Layer Caching]
+**Learning:** In the `Dockerfile`, `COPY` operations for application code were occurring before installing system dependencies with `apt-get install`. This caused any changes in the application code to invalidate the `apt-get` cache, significantly slowing down subsequent Docker image builds because system packages had to be re-downloaded and re-installed every time.
+**Action:** Order Dockerfile instructions from least frequently changed to most frequently changed. Place `RUN apt-get install` commands for system dependencies before `COPY` instructions for application code so that application changes do not invalidate the system package cache.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,11 @@ RUN pip uninstall -y pip
 #Distroless is too limited for my use.
 # I use Python
 FROM python:3.12-slim-bookworm
-COPY --from=build_env /app /app
+# Optimize layer caching: Install system dependencies before copying the application
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git nano poppler-utils wget && \
     rm -rf /var/lib/apt/lists/*
+COPY --from=build_env /app /app
 
 # Default fava port number
 EXPOSE 5000


### PR DESCRIPTION
💡 What: Moved the `COPY --from=build_env /app /app` instruction to *after* the `RUN apt-get update` installation step in the runtime stage of the `Dockerfile`.
🎯 Why: Previously, any change to the application code inside `/app` or `build_env` would invalidate the cached `apt-get` layer, forcing all system packages to be re-downloaded and re-installed on every application change.
📊 Impact: Significantly speeds up subsequent cross-platform Docker builds (e.g., in CI/CD or locally) by allowing Docker to reuse the system dependency layer indefinitely, as it is no longer dependent on the state of the application code.
🔬 Measurement: Verify that subsequent `docker build` runs use the cached layer for the `apt-get` step when changes are made only to application files or dependencies.

---
*PR created automatically by Jules for task [10411341300503053771](https://jules.google.com/task/10411341300503053771) started by @grostim*